### PR TITLE
Get rid of forceReflow which is no longer in modern TiddlyWiki

### DIFF
--- a/framework/MgtdList.js
+++ b/framework/MgtdList.js
@@ -342,8 +342,6 @@ merge(config.macros,{
       if (!(dontShowEmpty == "yes" && emptyList))
         wikify(wikifyThis,place,null,tiddler);
 
-      forceReflow(); // fixes rendering issues. (but probably doubles up rendering time??)
-
     }
   }
 


### PR DESCRIPTION
See this tiddlyweb thread for a bit more info:

 http://groups.google.com/group/tiddlyweb/browse_frm/thread/9f88b888afba3f14

This doesn't address the forceReflow in the demo and empty html files because presumably those are built from other sources (and are on older tw versions).
