### PR TITLE
Fix for issue 38 related to broken functionality of "new dependent action"

### DIFF
--- a/layout/MonkeyGTDTheme.theme
+++ b/layout/MonkeyGTDTheme.theme
@@ -42,7 +42,7 @@
 	<span macro='toolbar closeTiddler closeOthers +editTiddler deleteTiddler > fields syncing permalink references jump'></span>
 	<span macro='newHere label:"new here" tag:Reference'></span>
 	<span macro='newJournalHere {{config.mGTD.getOptTxt("newjournaldateformat")?config.mGTD.getOptTxt("newjournaldateformat"):"DD-mmm-YY 0hh:0mm"}} tag:Reference'></span>
-	<span macro="showWhenTagged Action"><span macro="newSavedTiddler title:'new dependent action' label:'new dependent action' tag:{{'Action Future \[\['+tiddler.getByIndex('Realm')+'\]\] \[\['+tiddler.getParent('Context').join('\]\] \[\[')+'\]\] \[\['+tiddler.getParent('Project')+'\]\] \[\['+tiddler.title+'\]\]'}}"></span></span>
+	<span macro="showWhenTagged Action"><span macro="newSavedTiddler title:'new dependent action' label:'new dependent action' tag:{{'Action Future \[\['+tiddler.getByIndex('Realm').join('\]\] \[\[')+'\]\] \[\['+tiddler.getParent('Context').join('\]\] \[\[')+'\]\] \[\['+tiddler.getParent('Project')+'\]\] \[\['+tiddler.title+'\]\]'}}"></span></span>
 </div>
 <!--}}}-->
 

--- a/layout/MonkeyGTDTheme.theme
+++ b/layout/MonkeyGTDTheme.theme
@@ -42,7 +42,7 @@
 	<span macro='toolbar closeTiddler closeOthers +editTiddler deleteTiddler > fields syncing permalink references jump'></span>
 	<span macro='newHere label:"new here" tag:Reference'></span>
 	<span macro='newJournalHere {{config.mGTD.getOptTxt("newjournaldateformat")?config.mGTD.getOptTxt("newjournaldateformat"):"DD-mmm-YY 0hh:0mm"}} tag:Reference'></span>
-		<span macro="showWhenTagged Action"><span macro="newSavedTiddler title:'new dependent action' label:'new dependent action' tag:{{'Action Future [['+config.macros.mgtdList.getRealm()+']] [['+tiddler.getParent('Context')+']] [['+tiddler.getParent('Project')+']] [['+tiddler.title+']]'}}"></span></span>
+	<span macro="showWhenTagged Action"><span macro="newSavedTiddler title:'new dependent action' label:'new dependent action' tag:{{'Action Future \[\['+tiddler.getByIndex('Realm')+'\]\] \[\['+tiddler.getParent('Context').join('\]\] \[\[')+'\]\] \[\['+tiddler.getParent('Project')+'\]\] \[\['+tiddler.title+'\]\]'}}"></span></span>
 </div>
 <!--}}}-->
 

--- a/supporting/NewSavedTiddlerPlugin.js
+++ b/supporting/NewSavedTiddlerPlugin.js
@@ -3,6 +3,11 @@ config.macros.newSavedTiddler.handler = function(place,macroName,params,wikifier
 	if (readOnly) {
 		return false;
 	}
+	//
+	// temporarily fix global tiddler reference for possible usage in executable params
+	//
+	var currentTiddler = window.tiddler;
+	window.tiddler = tiddler;
 	var p = paramString.parseParams("anon",null,true,false,false);
 	var label = getParam(p,"label","NewSavedTiddler");
 	var tooltip = getParam(p,"tooltip","");
@@ -28,10 +33,17 @@ config.macros.newSavedTiddler.handler = function(place,macroName,params,wikifier
 	}
 	var btn = createTiddlyButton(place,label,tooltip,this.onClick);
 	btn.params = paramString;
+	btn.tiddler = tiddler; // save tiddler reference this button relates to
+	window.tiddler = currentTiddler; // restore global tiddler reference
 	return false;
 };
 
 config.macros.newSavedTiddler.onClick = function(e) {
+	//
+	// temporarily fix global tiddler reference for possible usage in executable params
+	//
+	var currentTiddler = window.tiddler;
+	window.tiddler = this.tiddler;
 	var p = this.params.parseParams("anon",null,true,false,false);
 	var titlePrompt = getParam(p,"prompt","");
 	//
@@ -71,6 +83,7 @@ config.macros.newSavedTiddler.onClick = function(e) {
 		autoSaveChanges(null,[tiddler]);
 		story.displayTiddler(this,title);
 	}
+	window.tiddler = currentTiddler; // restore global tiddler reference
 	return false;
 }
 

--- a/views/TitleButtons.tiddler
+++ b/views/TitleButtons.tiddler
@@ -65,7 +65,7 @@
   <br style="clear:left"/>
   <div class="floatleft">
     <span class="label">Depends on:</span><br/><span macro="multiSelectTag Action allowNone:on"></span><span macro="linkToParent Action"></span>
-   <!-- fixme. broken in 2.4.1 but works in 2.4.3?: <span macro="newSavedTiddler title:'new dependent action' label:'+ dependent action' tag:{{'Action Future [['+config.macros.mgtdList.getRealm()+']] [['+tiddler.getParent('Context')+']] [['+tiddler.getParent('Project')+']] [['+tiddler.title +']]'}}"></span> -->
+    <span macro="newSavedTiddler title:'new dependent action' label:'+ dependent action' tag:{{'Action Future \[\['+tiddler.getByIndex('Realm')+'\]\] \[\['+tiddler.getParent('Context').join('\]\] \[\[')+'\]\] \[\['+tiddler.getParent('Project')+'\]\] \[\['+tiddler.title+'\]\]'}}"></span>
   </div>
   <div class="clearboth"></div>
  </div>

--- a/views/TitleButtons.tiddler
+++ b/views/TitleButtons.tiddler
@@ -65,7 +65,7 @@
   <br style="clear:left"/>
   <div class="floatleft">
     <span class="label">Depends on:</span><br/><span macro="multiSelectTag Action allowNone:on"></span><span macro="linkToParent Action"></span>
-    <span macro="newSavedTiddler title:'new dependent action' label:'+ dependent action' tag:{{'Action Future \[\['+tiddler.getByIndex('Realm')+'\]\] \[\['+tiddler.getParent('Context').join('\]\] \[\[')+'\]\] \[\['+tiddler.getParent('Project')+'\]\] \[\['+tiddler.title+'\]\]'}}"></span>
+    <span macro="newSavedTiddler title:'new dependent action' label:'+ dependent action' tag:{{'Action Future \[\['+tiddler.getByIndex('Realm').join('\]\] \[\[')+'\]\] \[\['+tiddler.getParent('Context').join('\]\] \[\[')+'\]\] \[\['+tiddler.getParent('Project')+'\]\] \[\['+tiddler.title+'\]\]'}}"></span>
   </div>
   <div class="clearboth"></div>
  </div>


### PR DESCRIPTION
The given commit fixes several problems related to 'new dependent action' functionality:

1) Escaped squared brackets in evaluated macro params with backslashes

The reason for the broken functionality are missing backslashes escaping the squared brackets within the executable part of the macro params. Without escaping backslashes the regexp defined in String.prototype.parseParams was not able to match the desired tokens properly. I'm not a regexp expert. So I can't say that I fully understood the cause. But after having seen the following regexp definition for double squared tokens:

`var dblSquare = "(?:\\[\\[((?:\\s|\\S)*?)\\]\\])";`

I just tried to escape the brackets... and it was working well.

So instead of:

`tag:{{'Action Future [['+config.macros.mgtdList.getRealm()+']] [['+tiddler.getParent('Context')+']] ...}}`

the evaluated part must be written like:

`tag:{{'Action Future \[\['+config.macros.mgtdList.getRealm()+'\]\] \[\['+tiddler.getParent('Context')+'\]\] ...}}`

> Correspondly changed the related parts in 'TitleButtons' (which has been re-enabled in the commit) as well as in 'MonkeyGTDTheme#ViewTemplateToolbar'.

2) Wrong current global tiddler reference

But even after this fix the behavior was still strange. When having two tasks opened (example: task1 and task2) and clicking on the 'new dependent action' button of the first one (task1), then the new task refers to the other opened tiddler as the dependend action (task2). If the other tiddler is not an action at all, e.g. a dashboard, the entry of the dependent action was the title of the dashboard - not the action which has been clicked.

The reason for this strange behavior is the fact, that within the evaluated part of the macro params any reference to 'tiddler' refers to the global reference stored in 'window.tiddler'. As it seems, when clicking a button on a tiddler it is not garanteed that the window.tiddler references the tiddler I have clicked... but any tiddler which was the current one before.

> For this reason the commit also introduces a fix within 'NewSavedTiddlerPlugin':
> - temporarily setting the global reference to the tiddler which executes the macro in both 'handler' as well as 'onClick' function
> - saving the tiddler reference the button relates to as property of the button in order to be able to access it during the 'onClick' function

Possilby it would not be necessary to set the global reference within the 'handler' function of the newSavedTiddler macro. But I was not sure about the behavior in TW core. For sure it is required in the 'onClick' function though.

3) Transfering tiddlers realm to the dependent action

When everything works fine, the current implementation of the 'new dependent action' does not transfer the realm of the original action, but sets the realm with 'config.macros.mgtdList.getRealm()'. In my view it is most likely that a dependent action will reside in the same realm. So when creating a dependent action which is in the realm "Personal", I would like to have a dependent action which also has the realm "Personal", not "Work". With the current implementation the realm passed to the dependent action is always "Work" (respectively the realm with the highest priority).

> The commit fixes this by using `tiddler.getByIndex('Realm')` instead of `config.macros.mgtdList.getRealm()` in the evaluated part of the macro params.

4) Transfering multiple contexts to the dependent action

The current implementation expects only one context to be enalbed on an action. When having enabled multiple contexts, the resulting tag is:

`[[Errand,Home,Low Energy]]`

as `tiddler.getParent('Context')` correctly returns an array of all action contexts. With this tag the context definition transfered to the dependent action is broken, of course.

> When using `tiddler.getParent('Context').join('\]\] \[\[')` instead of just `tiddler.getParent('Context')` the result will be as expected:

`Errand Home [[Low Energy]]`
# 

That's all so far. Thank you in advance for taking these fixes into consideration.

Best regards.
